### PR TITLE
Use docker subcommand "compose" instead of requiring separate docker-compose binaries

### DIFF
--- a/control-env.sh
+++ b/control-env.sh
@@ -2,7 +2,7 @@
 
 function stop {
   echo "Stopping and removing containers"
-  docker-compose --project-name wksp down
+  docker compose --project-name wksp down
 }
 
 function cleanup {
@@ -14,7 +14,7 @@ function cleanup {
 
 function start {
   echo "Starting up"
-  docker-compose --project-name wksp up -d
+  docker compose --project-name wksp up -d
 }
 
 function update {
@@ -22,7 +22,7 @@ function update {
   git pull --all
 
   echo "Updating docker images ..."
-  docker-compose --project-name wksp pull
+  docker compose --project-name wksp pull
 
   echo "You probably should restart"
 }
@@ -78,7 +78,7 @@ case $1 in
     ;;
 
   logs )
-  docker-compose --project-name wksp logs -f
+  docker compose --project-name wksp logs -f
     ;;
 
   token )
@@ -88,7 +88,7 @@ case $1 in
   superset-start )
   superset-start
     ;;
-  
+
   superset-stop )
   superset-stop
     ;;

--- a/vm/install-docker.sh
+++ b/vm/install-docker.sh
@@ -27,10 +27,6 @@ sudo usermod -aG docker "${USER}"
 
 sudo systemctl enable docker
 
-# Docker Compose
-sudo curl -L https://github.com/docker/compose/releases/download/1.24.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
-sudo chmod +x /usr/local/bin/docker-compose
-
 # Cleanup
 sudo apt-get -y autoremove
 

--- a/vm/install-script.sh
+++ b/vm/install-script.sh
@@ -17,9 +17,9 @@ sudo apt-get install -y git \
   maven
 
 ## Scala
-# IMPORTANT: Make sure scala version is the same as Spark 
+# IMPORTANT: Make sure scala version is the same as Spark
 # have been compiled to. Run spark-shell
-# 
+#
 sudo apt-get -y remove --auto-remove scala-library scala
 sudo apt-get -y purge scala-library* scala*
 
@@ -56,10 +56,6 @@ sudo apt-get install -y docker-ce
 sudo groupadd docker
 sudo usermod -aG docker "${USER}"
 
-# Docker Compose
-sudo curl -L https://github.com/docker/compose/releases/download/1.24.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
-sudo chmod +x /usr/local/bin/docker-compose
-
 # Cleanup
 sudo apt-get -y autoremove
 
@@ -71,4 +67,4 @@ cd ~
 git clone https://github.com/arjones/bigdata-workshop-es.git
 
 cd bigdata-workshop-es
-docker-compose pull
+docker compose pull


### PR DESCRIPTION
- Replaces usage of `docker-compose` to just `docker compose`, which is part of Docker and [a drop-in replacement of docker-compose](https://docs.docker.com/compose/cli-command-compatibility/)
- I've also removed the explicit installation of the `docker-compose` binary wherever I've found it. I've not tested this part ⚠️, but as far as I can tell, the `docker compose` subcommand should already be included in most installations of `docker`.